### PR TITLE
feat: 增强日志与调试信息输出

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker Image
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
     tags: ["v*"]
     paths:
       - "backend/**"

--- a/.gitignore
+++ b/.gitignore
@@ -160,5 +160,4 @@ test_*.py
 .claude
 .omx
 .omc
-.ace-tools
-
+.ace-tool/

--- a/backend/services/keyword_monitor.py
+++ b/backend/services/keyword_monitor.py
@@ -1472,7 +1472,7 @@ class KeywordMonitorService:
                         "terminal AI failure" if is_terminal else "failed",
                         rule.task_name,
                         exc,
-                        exc_info=not is_terminal,
+                        exc_info=True,
                     )
                     self._append_rule_log(
                         rule,

--- a/backend/services/keyword_monitor.py
+++ b/backend/services/keyword_monitor.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from backend.core.config import get_settings
 from backend.services.push_notifications import send_keyword_push
+from tg_signer.log_utils import safe_ai_request_meta, safe_ai_result_meta, safe_text_preview
 from backend.utils.account_locks import get_account_lock
 from backend.utils.proxy import build_proxy_dict
 from backend.utils.tg_session import (
@@ -1108,13 +1109,23 @@ class KeywordMonitorService:
 
         if action_id == 5:
             query = (message.text or message.caption or "").strip()
-            answer = (
-                await ai_tools.calculate_problem(
-                    query,
-                    system_prompt=action.get("ai_prompt"),
-                )
-                or ""
-            ).strip()
+            model = ai_tools.default_model
+            logger.info(f"关键词监听 AI 请求 | chat={target_chat_id} | {safe_ai_request_meta(method='calculate_problem', model=model, query_chars=len(query))}")
+            _start = time.monotonic()
+            try:
+                answer = (
+                    await ai_tools.calculate_problem(
+                        query,
+                        system_prompt=action.get("ai_prompt"),
+                    )
+                    or ""
+                ).strip()
+                _elapsed = (time.monotonic() - _start) * 1000
+                logger.info(f"关键词监听 AI 响应 | chat={target_chat_id} | {safe_ai_result_meta(method='calculate_problem', model=model, elapsed_ms=_elapsed, response_chars=len(answer))}")
+            except Exception as e:
+                _elapsed = (time.monotonic() - _start) * 1000
+                logger.error(f"关键词监听 AI 调用失败 | chat={target_chat_id} | method=calculate_problem elapsed_ms={_elapsed:.0f} error={type(e).__name__}: {safe_text_preview(e, 200)}")
+                return False
             if not answer:
                 return False
             await self._call_client_with_retry(
@@ -1126,13 +1137,23 @@ class KeywordMonitorService:
 
         if action_id == 6:
             image_bytes = await self._download_photo_bytes(client, message)
-            answer = (
-                await ai_tools.extract_text_by_image(
-                    image_bytes,
-                    system_prompt=action.get("ai_prompt"),
-                )
-                or ""
-            ).strip()
+            model = ai_tools.default_model
+            logger.info(f"关键词监听 AI 请求 | chat={target_chat_id} | {safe_ai_request_meta(method='extract_text_by_image', model=model, has_image=True, image_bytes=len(image_bytes))}")
+            _start = time.monotonic()
+            try:
+                answer = (
+                    await ai_tools.extract_text_by_image(
+                        image_bytes,
+                        system_prompt=action.get("ai_prompt"),
+                    )
+                    or ""
+                ).strip()
+                _elapsed = (time.monotonic() - _start) * 1000
+                logger.info(f"关键词监听 AI 响应 | chat={target_chat_id} | {safe_ai_result_meta(method='extract_text_by_image', model=model, elapsed_ms=_elapsed, response_chars=len(answer))}")
+            except Exception as e:
+                _elapsed = (time.monotonic() - _start) * 1000
+                logger.error(f"关键词监听 AI 调用失败 | chat={target_chat_id} | method=extract_text_by_image elapsed_ms={_elapsed:.0f} error={type(e).__name__}: {safe_text_preview(e, 200)}")
+                return False
             if not answer:
                 return False
             await self._call_client_with_retry(
@@ -1144,13 +1165,23 @@ class KeywordMonitorService:
 
         if action_id == 7:
             query = (message.text or message.caption or "").strip()
-            answer = (
-                await ai_tools.calculate_problem(
-                    query,
-                    system_prompt=action.get("ai_prompt"),
-                )
-                or ""
-            ).strip()
+            model = ai_tools.default_model
+            logger.info(f"关键词监听 AI 请求 | chat={target_chat_id} | {safe_ai_request_meta(method='calculate_problem', model=model, query_chars=len(query))}")
+            _start = time.monotonic()
+            try:
+                answer = (
+                    await ai_tools.calculate_problem(
+                        query,
+                        system_prompt=action.get("ai_prompt"),
+                    )
+                    or ""
+                ).strip()
+                _elapsed = (time.monotonic() - _start) * 1000
+                logger.info(f"关键词监听 AI 响应 | chat={target_chat_id} | {safe_ai_result_meta(method='calculate_problem', model=model, elapsed_ms=_elapsed, response_chars=len(answer))}")
+            except Exception as e:
+                _elapsed = (time.monotonic() - _start) * 1000
+                logger.error(f"关键词监听 AI 调用失败 | chat={target_chat_id} | method=calculate_problem elapsed_ms={_elapsed:.0f} error={type(e).__name__}: {safe_text_preview(e, 200)}")
+                return False
             if not answer:
                 return False
             proxy_action = {"action": 3, "text": answer}
@@ -1167,12 +1198,22 @@ class KeywordMonitorService:
             image_bytes = await self._download_photo_bytes(client, message)
             question_text = (message.caption or message.text or "").strip() or "Choose the correct option"
             options = [button_text for _, _, button_text in clickable_buttons]
-            result_indexes = await ai_tools.choose_options_by_image(
-                image_bytes,
-                question_text,
-                list(enumerate(options, start=1)),
-                system_prompt=action.get("ai_prompt"),
-            )
+            model = ai_tools.default_model
+            logger.info(f"关键词监听 AI 请求 | chat={target_chat_id} | {safe_ai_request_meta(method='choose_options_by_image', model=model, has_image=True, image_bytes=len(image_bytes), query_chars=len(question_text), options_count=len(options))}")
+            _start = time.monotonic()
+            try:
+                result_indexes = await ai_tools.choose_options_by_image(
+                    image_bytes,
+                    question_text,
+                    list(enumerate(options, start=1)),
+                    system_prompt=action.get("ai_prompt"),
+                )
+                _elapsed = (time.monotonic() - _start) * 1000
+                logger.info(f"关键词监听 AI 响应 | chat={target_chat_id} | {safe_ai_result_meta(method='choose_options_by_image', model=model, elapsed_ms=_elapsed, result_type='list', result_count=len(result_indexes or []))}")
+            except Exception as e:
+                _elapsed = (time.monotonic() - _start) * 1000
+                logger.error(f"关键词监听 AI 调用失败 | chat={target_chat_id} | method=choose_options_by_image elapsed_ms={_elapsed:.0f} error={type(e).__name__}: {safe_text_preview(e, 200)}")
+                return False
             clicked = 0
             for result_index in result_indexes:
                 if result_index == 0:

--- a/backend/services/keyword_monitor.py
+++ b/backend/services/keyword_monitor.py
@@ -26,6 +26,11 @@ from backend.utils.tg_session import (
 
 logger = logging.getLogger("backend.keyword_monitor")
 settings = get_settings()
+
+
+class TerminalAIActionError(Exception):
+    """AI 调用发生不可恢复错误，后续动作应立即失败而非重试"""
+    pass
 _PYROGRAM_IMPORT_ERROR: Exception | None = None
 
 try:
@@ -1125,7 +1130,7 @@ class KeywordMonitorService:
             except Exception as e:
                 _elapsed = (time.monotonic() - _start) * 1000
                 logger.error(f"关键词监听 AI 调用失败 | chat={target_chat_id} | method=calculate_problem elapsed_ms={_elapsed:.0f} error={type(e).__name__}: {safe_text_preview(e, 200)}")
-                return False
+                raise TerminalAIActionError(f"AI calculate_problem failed: {type(e).__name__}") from e
             if not answer:
                 return False
             await self._call_client_with_retry(
@@ -1153,7 +1158,7 @@ class KeywordMonitorService:
             except Exception as e:
                 _elapsed = (time.monotonic() - _start) * 1000
                 logger.error(f"关键词监听 AI 调用失败 | chat={target_chat_id} | method=extract_text_by_image elapsed_ms={_elapsed:.0f} error={type(e).__name__}: {safe_text_preview(e, 200)}")
-                return False
+                raise TerminalAIActionError(f"AI extract_text_by_image failed: {type(e).__name__}") from e
             if not answer:
                 return False
             await self._call_client_with_retry(
@@ -1181,7 +1186,7 @@ class KeywordMonitorService:
             except Exception as e:
                 _elapsed = (time.monotonic() - _start) * 1000
                 logger.error(f"关键词监听 AI 调用失败 | chat={target_chat_id} | method=calculate_problem elapsed_ms={_elapsed:.0f} error={type(e).__name__}: {safe_text_preview(e, 200)}")
-                return False
+                raise TerminalAIActionError(f"AI calculate+click failed: {type(e).__name__}") from e
             if not answer:
                 return False
             proxy_action = {"action": 3, "text": answer}
@@ -1213,7 +1218,7 @@ class KeywordMonitorService:
             except Exception as e:
                 _elapsed = (time.monotonic() - _start) * 1000
                 logger.error(f"关键词监听 AI 调用失败 | chat={target_chat_id} | method=choose_options_by_image elapsed_ms={_elapsed:.0f} error={type(e).__name__}: {safe_text_preview(e, 200)}")
-                return False
+                raise TerminalAIActionError(f"AI choose_options_by_image failed: {type(e).__name__}") from e
             clicked = 0
             for result_index in result_indexes:
                 if result_index == 0:
@@ -1457,17 +1462,21 @@ class KeywordMonitorService:
                         timeout=timeout + 1,
                     )
                 except Exception as exc:
-                    logger.warning(
-                        "Keyword monitor continue action %s/%s failed for task %s: %s",
+                    is_terminal = isinstance(exc, TerminalAIActionError)
+                    log_level = logging.ERROR if is_terminal else logging.WARNING
+                    logger.log(
+                        log_level,
+                        "Keyword monitor continue action %s/%s %s for task %s: %s",
                         index,
                         len(continue_actions),
+                        "terminal AI failure" if is_terminal else "failed",
                         rule.task_name,
                         exc,
-                        exc_info=True,
+                        exc_info=not is_terminal,
                     )
                     self._append_rule_log(
                         rule,
-                        f"后续动作 {index}/{len(rendered_actions)} 执行异常：{exc}",
+                        f"后续动作 {index}/{len(rendered_actions)} {'AI 调用不可恢复失败' if is_terminal else '执行异常'}：{exc}",
                     )
                     return
                 if not result:

--- a/backend/services/sign_tasks.py
+++ b/backend/services/sign_tasks.py
@@ -3222,7 +3222,7 @@ class SignTaskService:
         return any(key[1] == task_name for key, running in self._active_tasks.items() if running)
 
     async def run_task_with_logs(
-        self, account_name: str, task_name: str, run_id: str = None
+        self, account_name: str, task_name: str, run_id: Optional[str] = None
     ) -> Dict[str, Any]:
         """运行任务并实时捕获日志 (In-Process)"""
 

--- a/backend/services/sign_tasks.py
+++ b/backend/services/sign_tasks.py
@@ -3441,7 +3441,8 @@ class SignTaskService:
                     notify_on_failure=task_notify_on_failure,
                 )
             # 脱敏异常摘要写入任务日志流（会持久化、API 展示、通知外发）
-            error_msg = f"任务执行出错: {safe_exception_summary(e, 300)}"
+            _run_tag = f"[run_id={run_id}] " if run_id else ""
+            error_msg = f"{_run_tag}任务执行出错: {safe_exception_summary(e, 300)}"
             self._active_logs[task_key].append(error_msg)
             # 脱敏 traceback 写入任务日志流
             _tb = traceback.format_exc()
@@ -3450,7 +3451,8 @@ class SignTaskService:
                 for _line in _safe_tb.splitlines():
                     self._active_logs[task_key].append(f"  {_line}")
             # 服务端日志保留完整 exc_info（仅写入本地日志文件，不外发）
-            _service_logger.error(f"任务执行出错 [{account_name}/{task_name}]: {e}", exc_info=True)
+            _run_id_tag = f" [run_id={run_id}]" if run_id else ""
+            _service_logger.error(f"任务执行出错{_run_id_tag} [{account_name}/{task_name}]: {e}", exc_info=True)
         finally:
             self._account_last_run_end[account_name] = time.time()
             try:

--- a/backend/services/sign_tasks.py
+++ b/backend/services/sign_tasks.py
@@ -35,6 +35,7 @@ from backend.utils.tg_session import (
 from backend.utils.time import utc_now_iso
 from tg_signer.async_utils import create_logged_task
 from tg_signer.core import UserSigner, get_client
+from tg_signer.log_utils import safe_exception_summary, safe_traceback_preview
 
 settings = get_settings()
 
@@ -1526,7 +1527,7 @@ class SignTaskService:
                         with open(config_file, "w", encoding="utf-8") as f:
                             json.dump(config, f, ensure_ascii=False, indent=2)
                     except Exception as e:
-                        _service_logger.debug(f"更新任务配置 last_run 失败: {e}")
+                        _service_logger.warning(f"更新任务配置 last_run 失败: {e}")
 
             # 2. 更新内存缓存 (关键优化：避免置空 self._tasks_cache)
             if self._tasks_cache is not None:
@@ -1536,7 +1537,7 @@ class SignTaskService:
                         break
 
         except Exception as e:
-            _service_logger.debug(f"保存运行信息失败: {str(e)}")
+            _service_logger.warning(f"保存运行信息失败: {str(e)}")
 
     def _append_scheduler_log(self, filename: str, message: str) -> None:
         try:
@@ -3145,7 +3146,7 @@ class SignTaskService:
             result: Dict[str, Any]
             state = "finished"
             try:
-                result = await self.run_task_with_logs(account_name, task_name)
+                result = await self.run_task_with_logs(account_name, task_name, run_id=run_id)
             except asyncio.CancelledError:
                 state = "cancelled"
                 result = {
@@ -3221,7 +3222,7 @@ class SignTaskService:
         return any(key[1] == task_name for key, running in self._active_tasks.items() if running)
 
     async def run_task_with_logs(
-        self, account_name: str, task_name: str
+        self, account_name: str, task_name: str, run_id: str = None
     ) -> Dict[str, Any]:
         """运行任务并实时捕获日志 (In-Process)"""
 
@@ -3241,10 +3242,14 @@ class SignTaskService:
         # 这里我们希望排队等待，还是直接报错？
         # 考虑到定时任务同时触发，应该排队执行。
         _service_logger.debug(f"等待获取账号锁 {account_name}...")
+        if run_id:
+            _service_logger.info(f"任务运行 run_id={run_id} [{account_name}/{task_name}]")
 
         task_key = self._task_key(account_name, task_name)
         self._active_tasks[task_key] = True
         self._active_logs[task_key] = []
+        if run_id:
+            self._active_logs[task_key].append(f"[run_id={run_id}]")
 
         # 获取 logger 实例
         tg_logger = logging.getLogger("tg-signer")
@@ -3435,12 +3440,17 @@ class SignTaskService:
                     invalid_message,
                     notify_on_failure=task_notify_on_failure,
                 )
-            error_msg = f"任务执行出错: {str(e)}"
+            # 脱敏异常摘要写入任务日志流（会持久化、API 展示、通知外发）
+            error_msg = f"任务执行出错: {safe_exception_summary(e, 300)}"
             self._active_logs[task_key].append(error_msg)
-            # 打印堆栈以便调试
-            traceback.print_exc()
-            logger = logging.getLogger("backend")
-            logger.error(error_msg)
+            # 脱敏 traceback 写入任务日志流
+            _tb = traceback.format_exc()
+            _safe_tb = safe_traceback_preview(_tb, max_lines=6, max_line_chars=200)
+            if _safe_tb:
+                for _line in _safe_tb.splitlines():
+                    self._active_logs[task_key].append(f"  {_line}")
+            # 服务端日志保留完整 exc_info（仅写入本地日志文件，不外发）
+            _service_logger.error(f"任务执行出错 [{account_name}/{task_name}]: {e}", exc_info=True)
         finally:
             self._account_last_run_end[account_name] = time.time()
             try:

--- a/tg_signer/ai_tools.py
+++ b/tg_signer/ai_tools.py
@@ -6,6 +6,7 @@ import logging
 import os
 import pathlib
 import re
+import time
 from typing import TYPE_CHECKING, Any, Union
 
 import json_repair
@@ -19,6 +20,7 @@ except Exception:  # pragma: no cover - Pillow is optional at runtime
 if TYPE_CHECKING:
     from openai import AsyncOpenAI  # 在性能弱的机器上导入openai包实在有些慢
 
+from tg_signer.log_utils import safe_text_preview
 from tg_signer.utils import UserInput, print_to_user
 
 DEFAULT_MODEL = "gpt-4o"
@@ -260,6 +262,7 @@ class AITools:
         if Image is None:
             return image
 
+        original_size = len(image)
         try:
             with Image.open(io.BytesIO(image)) as raw_image:
                 prepared = raw_image.convert("RGB")
@@ -275,7 +278,9 @@ class AITools:
         quality = cls._read_positive_int_env("AI_VISION_JPEG_QUALITY", 85, 40)
         output = io.BytesIO()
         prepared.save(output, format="JPEG", quality=quality, optimize=True)
-        return output.getvalue()
+        result = output.getvalue()
+        logger.debug(f"AI 图片预处理 | 原始: {original_size} bytes | 处理后: {len(result)} bytes | 尺寸: {prepared.size}")
+        return result
 
     @staticmethod
     def _format_option_lines(options: list[tuple[int, str]]) -> str:
@@ -296,7 +301,8 @@ class AITools:
                         break
 
         if isinstance(result, dict):
-            raise ValueError(f"AI result does not contain an option: {result}")
+            logger.error(f"AI 返回结果中未找到选项字段 | result_type={type(result).__name__} keys={list(result.keys())}")
+            raise ValueError(f"AI result does not contain an option: {type(result).__name__}")
 
         if isinstance(result, int):
             return result
@@ -315,7 +321,8 @@ class AITools:
                 if normalized_option and normalized_option in normalized_result:
                     return index
 
-        raise ValueError(f"Could not parse AI option result: {result}")
+        logger.error(f"AI 返回结果无法解析为选项索引 | result_type={type(result).__name__} result_chars={len(str(result))} options_count={len(options)}")
+        raise ValueError(f"Could not parse AI option result: {type(result).__name__}")
 
     @classmethod
     def _coerce_option_indexes(cls, result: Any, options: list[tuple[int, str]]) -> list[int]:
@@ -368,17 +375,25 @@ class AITools:
         if expect_json:
             kwargs["response_format"] = {"type": "json_object"}
 
+        _start = time.monotonic()
         try:
-            return await asyncio.wait_for(
+            result = await asyncio.wait_for(
                 client.chat.completions.create(**kwargs),
                 timeout=self._ai_timeout(),
             )
+            _elapsed = (time.monotonic() - _start) * 1000
+            _usage = getattr(result, "usage", None)
+            _tokens = ""
+            if _usage:
+                _tokens = f" | tokens: prompt={getattr(_usage, 'prompt_tokens', '?')} completion={getattr(_usage, 'completion_tokens', '?')}"
+            logger.debug(f"AI API 调用完成 | model={model} elapsed_ms={_elapsed:.0f}{_tokens}")
+            return result
         except Exception as exc:
             if not expect_json or not self._should_retry_without_json_mode(exc):
                 raise
             logger.warning(
                 "AI provider rejected structured JSON mode, retrying without response_format: %s",
-                exc,
+                safe_text_preview(exc, 200),
             )
             kwargs.pop("response_format", None)
             return await asyncio.wait_for(

--- a/tg_signer/ai_tools.py
+++ b/tg_signer/ai_tools.py
@@ -302,7 +302,7 @@ class AITools:
 
         if isinstance(result, dict):
             logger.error(f"AI 返回结果中未找到选项字段 | result_type={type(result).__name__} keys={list(result.keys())}")
-            raise ValueError(f"AI result does not contain an option: {type(result).__name__}")
+            raise ValueError(f"AI result does not contain an option: {safe_text_preview(result, 100)}")
 
         if isinstance(result, int):
             return result
@@ -322,7 +322,7 @@ class AITools:
                     return index
 
         logger.error(f"AI 返回结果无法解析为选项索引 | result_type={type(result).__name__} result_chars={len(str(result))} options_count={len(options)}")
-        raise ValueError(f"Could not parse AI option result: {type(result).__name__}")
+        raise ValueError(f"Could not parse AI option result: {safe_text_preview(result, 100)}")
 
     @classmethod
     def _coerce_option_indexes(cls, result: Any, options: list[tuple[int, str]]) -> list[int]:

--- a/tg_signer/ai_tools.py
+++ b/tg_signer/ai_tools.py
@@ -396,10 +396,18 @@ class AITools:
                 safe_text_preview(exc, 200),
             )
             kwargs.pop("response_format", None)
-            return await asyncio.wait_for(
+            _retry_start = time.monotonic()
+            result = await asyncio.wait_for(
                 client.chat.completions.create(**kwargs),
                 timeout=self._ai_timeout(),
             )
+            _retry_elapsed = (time.monotonic() - _retry_start) * 1000
+            _usage = getattr(result, "usage", None)
+            _tokens = ""
+            if _usage:
+                _tokens = f" | tokens: prompt={getattr(_usage, 'prompt_tokens', '?')} completion={getattr(_usage, 'completion_tokens', '?')}"
+            logger.debug(f"AI API 重试完成（无 JSON 模式） | model={model} elapsed_ms={_retry_elapsed:.0f}{_tokens}")
+            return result
 
     async def choose_option_by_image(
         self,

--- a/tg_signer/core.py
+++ b/tg_signer/core.py
@@ -54,6 +54,7 @@ from tg_signer.config import (
 
 from .ai_tools import AITools, OpenAIConfigManager
 from .async_utils import create_logged_task
+from .log_utils import safe_ai_request_meta, safe_ai_result_meta, safe_text_preview
 from .notification.server_chan import sc_send
 from .utils import UserInput, print_to_user
 
@@ -882,6 +883,7 @@ class BaseUserWorker(Generic[ConfigT]):
                         )
                         if print_chat:
                             print_to_user(readable_chat(chat))
+                        logger.debug(readable_chat(chat))
                     except Exception as e:
                         self.log(
                             f"处理 dialog 失败，已跳过: {type(e).__name__}: {e}",
@@ -893,6 +895,7 @@ class BaseUserWorker(Generic[ConfigT]):
                     f"get_dialogs 中断，返回已获取结果: {type(e).__name__}: {e}",
                     level="WARNING",
                 )
+            self.log(f"登录完成，获取到 {len(latest_chats)} 个对话")
 
             with open(
                 self.get_user_dir(me).joinpath("latest_chats.json"),
@@ -2518,17 +2521,28 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
             self._log_received_target_message(message)
             self.log("AI 正在分析计算题")
             self.log(f"题目内容：{self._normalize_log_text(message.text, 220)}")
-            if (action.ai_prompt or "").strip():
+            ai_prompt = action.ai_prompt if (action.ai_prompt or "").strip() else None
+            if ai_prompt:
                 self.log("当前 AI 动作使用自定义提示词")
-            answer = await self.get_ai_tools().calculate_problem(
-                message.text,
-                system_prompt=action.ai_prompt,
-            )
-            answer = (answer or "").strip()
+            model = self.get_ai_tools().default_model
+            self.log(f"AI 请求 | {safe_ai_request_meta(method='calculate_problem', model=model, query_chars=len(message.text), custom_prompt=bool(ai_prompt))}")
+            _start = time.monotonic()
+            try:
+                answer = await self.get_ai_tools().calculate_problem(
+                    message.text,
+                    system_prompt=ai_prompt,
+                )
+                _elapsed = (time.monotonic() - _start) * 1000
+                answer = (answer or "").strip()
+                self.log(f"AI 响应 | {safe_ai_result_meta(method='calculate_problem', model=model, elapsed_ms=_elapsed, response_chars=len(answer))}")
+            except Exception as e:
+                _elapsed = (time.monotonic() - _start) * 1000
+                self.log(f"AI 调用失败 | method=calculate_problem model={model} elapsed_ms={_elapsed:.0f} error={type(e).__name__}: {safe_text_preview(e, 200)}", level="ERROR")
+                raise
             if not answer:
                 self.log("AI 未返回有效答案", level="WARNING")
                 return False
-            self.log(f"AI 计算结果：{answer}")
+            self.log(f"AI 计算完成 | answer_chars={len(answer)} | 预览: {safe_text_preview(answer, 80)}", level="DEBUG")
             await self.send_message(message.chat.id, answer)
             return True
         return False
@@ -2548,17 +2562,28 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
         )
         image_buffer.seek(0)
         image_bytes = image_buffer.read()
-        if (action.ai_prompt or "").strip():
+        ai_prompt = action.ai_prompt if (action.ai_prompt or "").strip() else None
+        if ai_prompt:
             self.log("当前 AI 动作使用自定义提示词")
-        text = await self.get_ai_tools().extract_text_by_image(
-            image_bytes,
-            system_prompt=action.ai_prompt,
-        )
-        text = (text or "").strip()
+        model = self.get_ai_tools().default_model
+        self.log(f"AI 请求 | {safe_ai_request_meta(method='extract_text_by_image', model=model, has_image=True, image_bytes=len(image_bytes), custom_prompt=bool(ai_prompt))}")
+        _start = time.monotonic()
+        try:
+            text = await self.get_ai_tools().extract_text_by_image(
+                image_bytes,
+                system_prompt=ai_prompt,
+            )
+            _elapsed = (time.monotonic() - _start) * 1000
+            text = (text or "").strip()
+            self.log(f"AI 响应 | {safe_ai_result_meta(method='extract_text_by_image', model=model, elapsed_ms=_elapsed, response_chars=len(text))}")
+        except Exception as e:
+            _elapsed = (time.monotonic() - _start) * 1000
+            self.log(f"AI 调用失败 | method=extract_text_by_image model={model} elapsed_ms={_elapsed:.0f} error={type(e).__name__}: {safe_text_preview(e, 200)}", level="ERROR")
+            raise
         if not text:
             self.log("AI 未识别到可发送文本", level="WARNING")
             return False
-        self.log(f"AI 识别结果：{text}")
+        self.log(f"AI OCR 完成 | text_chars={len(text)} | 预览: {safe_text_preview(text, 80)}", level="DEBUG")
         await self.send_message(message.chat.id, text)
         return True
 
@@ -2569,17 +2594,28 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
             return False
         self._log_received_target_message(message)
         self.log("AI 正在计算按钮答案")
-        if (action.ai_prompt or "").strip():
+        ai_prompt = action.ai_prompt if (action.ai_prompt or "").strip() else None
+        if ai_prompt:
             self.log("当前 AI 动作使用自定义提示词")
-        answer = await self.get_ai_tools().calculate_problem(
-            message.text,
-            system_prompt=action.ai_prompt,
-        )
-        answer = (answer or "").strip()
+        model = self.get_ai_tools().default_model
+        self.log(f"AI 请求 | {safe_ai_request_meta(method='calculate_problem', model=model, query_chars=len(message.text), custom_prompt=bool(ai_prompt))}")
+        _start = time.monotonic()
+        try:
+            answer = await self.get_ai_tools().calculate_problem(
+                message.text,
+                system_prompt=ai_prompt,
+            )
+            _elapsed = (time.monotonic() - _start) * 1000
+            answer = (answer or "").strip()
+            self.log(f"AI 响应 | {safe_ai_result_meta(method='calculate_problem', model=model, elapsed_ms=_elapsed, response_chars=len(answer))}")
+        except Exception as e:
+            _elapsed = (time.monotonic() - _start) * 1000
+            self.log(f"AI 调用失败 | method=calculate_problem model={model} elapsed_ms={_elapsed:.0f} error={type(e).__name__}: {safe_text_preview(e, 200)}", level="ERROR")
+            raise
         if not answer:
             self.log("AI 未返回可用于点击的答案", level="WARNING")
             return False
-        self.log(f"AI 计算结果：{answer}")
+        self.log(f"AI 计算完成 | answer_chars={len(answer)} | 预览: {safe_text_preview(answer, 80)}", level="DEBUG")
         proxy_action = ClickKeyboardByTextAction(text=answer)
         return await self._click_keyboard_by_text(proxy_action, message)
 
@@ -2602,14 +2638,25 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
             question_text = (message.caption or message.text or "").strip()
             if not question_text:
                 question_text = "选择正确的选项"
-            if (action.ai_prompt or "").strip():
+            ai_prompt = action.ai_prompt if (action.ai_prompt or "").strip() else None
+            if ai_prompt:
                 self.log("当前 AI 动作使用自定义提示词")
-            result_indexes = await self.get_ai_tools().choose_options_by_image(
-                image_bytes,
-                question_text,
-                list(enumerate(options, start=1)),
-                system_prompt=action.ai_prompt,
-            )
+            model = self.get_ai_tools().default_model
+            self.log(f"AI 请求 | {safe_ai_request_meta(method='choose_options_by_image', model=model, has_image=True, image_bytes=len(image_bytes), query_chars=len(question_text), options_count=len(options), custom_prompt=bool(ai_prompt))}")
+            _start = time.monotonic()
+            try:
+                result_indexes = await self.get_ai_tools().choose_options_by_image(
+                    image_bytes,
+                    question_text,
+                    list(enumerate(options, start=1)),
+                    system_prompt=ai_prompt,
+                )
+                _elapsed = (time.monotonic() - _start) * 1000
+                self.log(f"AI 响应 | {safe_ai_result_meta(method='choose_options_by_image', model=model, elapsed_ms=_elapsed, result_type='list', result_count=len(result_indexes or []))}")
+            except Exception as e:
+                _elapsed = (time.monotonic() - _start) * 1000
+                self.log(f"AI 调用失败 | method=choose_options_by_image model={model} elapsed_ms={_elapsed:.0f} error={type(e).__name__}: {safe_text_preview(e, 200)}", level="ERROR")
+                raise
             if not result_indexes:
                 self.log("AI 未返回可点击选项", level="WARNING")
                 return False
@@ -2625,7 +2672,7 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
                     self.log(f"AI 返回了非法选项序号: {result_index}", level="WARNING")
                     return False
                 button_kind, target_btn, result = clickable_buttons[selected_idx]
-                self.log(f"AI 选择并点击选项：{result}")
+                self.log(f"AI 选择并点击选项 | index={selected_idx + 1} | preview={safe_text_preview(result, 60)}", level="DEBUG")
                 if button_kind == "inline":
                     if await self._click_inline_button(message, target_btn):
                         clicked += 1

--- a/tg_signer/log_utils.py
+++ b/tg_signer/log_utils.py
@@ -26,7 +26,7 @@ _SECRET_PATTERNS = [
     # 带凭据的 URL（http/https/socks4/socks5）
     re.compile(r"(?:https?|socks[45])://[^:]+:[^@]+@[^\s]+"),
     # Authorization header
-    re.compile(r"(?:authorization|x-api-key)\s*[:=]\s*\S+", re.IGNORECASE),
+    re.compile(r"(?:authorization|x-api-key)\s*[:=]\s*(?:\S+\s+)?\S+", re.IGNORECASE),
     # api_key=xxx 或 api_key: xxx 字段值
     re.compile(r"(?:api_key|api_secret|access_token|refresh_token)\s*[:=]\s*\S+", re.IGNORECASE),
 ]
@@ -94,7 +94,7 @@ def safe_ai_request_meta(
         f"model={model}",
     ]
     if has_image:
-        parts.append(f"has_image=true")
+        parts.append("has_image=true")
         if image_bytes > 0:
             parts.append(f"image_bytes={image_bytes}")
     if query_chars > 0:
@@ -102,7 +102,7 @@ def safe_ai_request_meta(
     if options_count > 0:
         parts.append(f"options_count={options_count}")
     if custom_prompt:
-        parts.append(f"custom_prompt=true")
+        parts.append("custom_prompt=true")
     return " | ".join(parts)
 
 
@@ -127,7 +127,16 @@ def safe_traceback_preview(tb: str, max_lines: int = 6, max_line_chars: int = 20
     tail = lines[-max_lines:]
     safe_lines = []
     for line in tail:
-        safe_lines.append(safe_text_preview(line, max_line_chars))
+        # 保留行首缩进（traceback 可读性），仅对内容部分脱敏
+        leading_spaces = len(line) - len(line.lstrip())
+        indent = line[:leading_spaces]
+        content = line[leading_spaces:]
+        content = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", content)
+        for pattern in _SECRET_PATTERNS:
+            content = pattern.sub("[REDACTED]", content)
+        if len(content) > max_line_chars:
+            content = content[:max_line_chars - 3] + "..."
+        safe_lines.append(f"{indent}{content}")
     return "\n".join(safe_lines)
 
 

--- a/tg_signer/log_utils.py
+++ b/tg_signer/log_utils.py
@@ -25,10 +25,10 @@ _SECRET_PATTERNS = [
     re.compile(r"(?<![A-Za-z0-9+/=])[A-Za-z0-9+/]{128,}={0,2}(?![A-Za-z0-9+/=])"),
     # 带凭据的 URL（http/https/socks4/socks5）
     re.compile(r"(?:https?|socks[45])://[^:]+:[^@]+@[^\s]+"),
-    # Authorization header
-    re.compile(r"(?:authorization|x-api-key)\s*[:=]\s*(?:\S+\s+)?\S+", re.IGNORECASE),
-    # api_key=xxx 或 api_key: xxx 字段值
-    re.compile(r"(?:api_key|api_secret|access_token|refresh_token)\s*[:=]\s*\S+", re.IGNORECASE),
+    # Authorization header（支持带引号：'Authorization': 'Bearer xxx'）
+    re.compile(r"""(?:['"]?(?:authorization|x-api-key)['"]?\s*[:=]\s*)(?:\S+\s+)?\S+""", re.IGNORECASE),
+    # api_key=xxx 或 'api_key': xxx 字段值（支持带引号）
+    re.compile(r"""(?:['"]?(?:api_key|api_secret|access_token|refresh_token)['"]?\s*[:=]\s*)['"]?\S+['"]?""", re.IGNORECASE),
 ]
 
 

--- a/tg_signer/log_utils.py
+++ b/tg_signer/log_utils.py
@@ -1,0 +1,157 @@
+"""
+日志脱敏与结构化工具
+提供统一的日志安全处理函数，防止敏感数据泄露到日志中
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+
+# 敏感字段模式：匹配 API key、session string、token 等
+_SECRET_PATTERNS = [
+    # OpenAI / 通用 sk-* API key
+    re.compile(r"sk-[A-Za-z0-9_-]{8,}"),
+    # Telegram session string（长 base64-like 字符串，通常 >100 字符）
+    re.compile(r"[A-Za-z0-9+/=_-]{80,}={0,2}"),
+    # Telegram bot token（数字:字母数字串）
+    re.compile(r"\d{8,12}:[A-Za-z0-9_-]{30,}"),
+    # Telegram api_hash（32 位十六进制）
+    re.compile(r"[0-9a-fA-F]{32}(?=[^0-9a-fA-F]|$)"),
+    # data:image base64 图片
+    re.compile(r"data:image/[a-z+]+;base64,[A-Za-z0-9+/=]{50,}"),
+    # 裸 base64 长片段（>=128 字符，可能含 = padding）
+    re.compile(r"(?<![A-Za-z0-9+/=])[A-Za-z0-9+/]{128,}={0,2}(?![A-Za-z0-9+/=])"),
+    # 带凭据的 URL（http/https/socks4/socks5）
+    re.compile(r"(?:https?|socks[45])://[^:]+:[^@]+@[^\s]+"),
+    # Authorization header
+    re.compile(r"(?:authorization|x-api-key)\s*[:=]\s*\S+", re.IGNORECASE),
+    # api_key=xxx 或 api_key: xxx 字段值
+    re.compile(r"(?:api_key|api_secret|access_token|refresh_token)\s*[:=]\s*\S+", re.IGNORECASE),
+]
+
+
+def redact_secret(value: Any) -> str:
+    """脱敏敏感值，只保留前后 4 位，中间用 *** 替代"""
+    s = str(value) if value is not None else ""
+    if not s:
+        return ""
+    if len(s) <= 8:
+        return "***"
+    return f"{s[:4]}***{s[-4:]}"
+
+
+def safe_text_preview(text: Any, max_chars: int = 120) -> str:
+    """
+    安全的文本预览：去控制字符、折叠空白、截断、过滤敏感信息
+    用于日志中安全展示用户消息、AI prompt/response 等
+    """
+    if text is None:
+        return ""
+    s = str(text)
+    # 去除控制字符（保留换行和空格）
+    s = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", s)
+    # 折叠空白
+    s = re.sub(r"\s+", " ", s).strip()
+    # 过滤敏感模式
+    for pattern in _SECRET_PATTERNS:
+        s = pattern.sub("[REDACTED]", s)
+    # 截断
+    if len(s) > max_chars:
+        s = s[: max_chars - 3] + "..."
+    return s
+
+
+def safe_proxy_meta(proxy: Optional[dict]) -> str:
+    """
+    安全输出代理元数据，只输出 scheme/host/port，禁止输出 username/password
+    """
+    if not proxy:
+        return "none"
+    scheme = proxy.get("scheme", proxy.get("proxy_type", "unknown"))
+    hostname = proxy.get("hostname", "?")
+    port = proxy.get("port", "?")
+    return f"{scheme}://{hostname}:{port}"
+
+
+def safe_ai_request_meta(
+    *,
+    method: str,
+    model: str,
+    has_image: bool = False,
+    image_bytes: int = 0,
+    query_chars: int = 0,
+    options_count: int = 0,
+    custom_prompt: bool = False,
+) -> str:
+    """
+    安全的 AI 请求元数据，用于 INFO 日志
+    只记录结构化元数据，不记录原始内容
+    """
+    parts = [
+        f"method={method}",
+        f"model={model}",
+    ]
+    if has_image:
+        parts.append(f"has_image=true")
+        if image_bytes > 0:
+            parts.append(f"image_bytes={image_bytes}")
+    if query_chars > 0:
+        parts.append(f"query_chars={query_chars}")
+    if options_count > 0:
+        parts.append(f"options_count={options_count}")
+    if custom_prompt:
+        parts.append(f"custom_prompt=true")
+    return " | ".join(parts)
+
+
+def safe_exception_summary(exc: Exception, max_chars: int = 300) -> str:
+    """
+    安全的异常摘要：脱敏异常消息，用于任务日志流
+    不泄露 session_string、proxy URL、API key 等敏感信息
+    """
+    text = safe_text_preview(str(exc), max_chars)
+    return f"{type(exc).__name__}: {text}"
+
+
+def safe_traceback_preview(tb: str, max_lines: int = 6, max_line_chars: int = 200) -> str:
+    """
+    安全的 traceback 预览：脱敏每行内容，限制行数
+    用于写入任务日志流（会持久化、API 展示、通知外发）
+    """
+    if not tb or tb == "NoneType: None\n":
+        return ""
+    lines = tb.strip().splitlines()
+    # 只保留最后 N 行（最有排障价值的部分）
+    tail = lines[-max_lines:]
+    safe_lines = []
+    for line in tail:
+        safe_lines.append(safe_text_preview(line, max_line_chars))
+    return "\n".join(safe_lines)
+
+
+def safe_ai_result_meta(
+    *,
+    method: str,
+    model: str,
+    elapsed_ms: float,
+    result_type: str = "",
+    result_count: int = 0,
+    response_chars: int = 0,
+) -> str:
+    """
+    安全的 AI 响应元数据，用于 INFO 日志
+    """
+    parts = [
+        f"method={method}",
+        f"model={model}",
+        f"elapsed_ms={elapsed_ms:.0f}",
+    ]
+    if result_type:
+        parts.append(f"result_type={result_type}")
+    if result_count > 0:
+        parts.append(f"result_count={result_count}")
+    if response_chars > 0:
+        parts.append(f"response_chars={response_chars}")
+    return " | ".join(parts)


### PR DESCRIPTION
## 改动内容

- 新增 `tg_signer/log_utils.py` 日志脱敏工具，覆盖 API key、session string、bot token、api_hash、base64、proxy 密码、Authorization header 等敏感模式
- AI 调用（识图选选项、计算题、图片 OCR、计算后点击）增加结构化请求/响应/失败日志，记录模型、耗时、选项数、图片大小等元数据，不记录 prompt/response 原文
- 关键词监听后台 AI 动作增加请求/响应/失败日志
- `login()` 对话列表降级为 DEBUG，新增登录完成汇总 INFO
- `sign_tasks.py` 关键错误从 debug 修正为 warning/error
- `run_id` 传入任务流首行，便于关联同一次运行
- traceback 脱敏后写入任务日志流，服务端日志保留完整 exc_info
- `ai_tools.py` 图片预处理记录大小、API 调用记录耗时和 token 用量

## 安全保障

日志中不记录以下敏感信息：
- API key、session_string、api_hash
- proxy 密码、完整 URL
- AI prompt/response 原文
- 图片 base64
- Telegram 私聊原文

## 改动文件

| 文件 | 说明 |
|------|------|
| `tg_signer/log_utils.py` | 新增，日志脱敏工具函数 |
| `tg_signer/core.py` | login 分流 + AI 结构化日志 |
| `tg_signer/ai_tools.py` | 图片预处理、API 耗时、异常增强 |
| `backend/services/sign_tasks.py` | 错误级别修正、run_id 关联、traceback 脱敏 |
| `backend/services/keyword_monitor.py` | 后台 AI 动作日志 |
| `.gitignore` | 修正 .ace-tool 目录规则 |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/silentely/tg-signpulse/pull/1" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Enhance logging, debugging, and safety around AI calls, task execution, and login flows while introducing centralized log desensitization utilities.

New Features:
- Introduce a shared log_utils module providing text previews, AI request/response metadata helpers, proxy metadata formatting, and desensitized exception/traceback formatting for safe logging.
- Add structured, metadata-only logging for AI interactions in core flows and keyword monitoring, covering request parameters, response sizes, timing, and failures without logging raw content.

Enhancements:
- Lower noisy login dialog output to debug level and add a concise login completion summary log entry.
- Log image preprocessing details for AI vision calls, including original and processed image sizes and dimensions.
- Improve AI option parsing diagnostics by logging result types and sizes before raising errors, and log AI provider retry reasons in a safer, truncated form.
- Associate a run_id with task executions and in-memory log buffers to make individual runs easier to trace in logs.
- Adjust task scheduler error handling to write desensitized exception summaries and sanitized traceback previews to task log streams while keeping full stack traces only in backend service logs.
- Increase log severity for failures when saving run metadata and task configuration updates to make operational issues more visible.

Chores:
- Update .gitignore to correctly ignore the .ace-tool directory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
引入统一脱敏与结构化日志，覆盖 AI 调用、任务运行与登录流程，提升排障效率并保护敏感信息。支持 `run_id` 关联与更安全的异常摘要，限制重试，并改进关键字监控的错误记录。

- **New Features**
  - 新增 `tg_signer/log_utils.py`：统一脱敏（API key、session_string、bot token、`api_hash`、base64、代理凭据、`Authorization` 等，支持带引号）、安全预览与 traceback 截断；提供 AI 请求/响应元数据工具。
  - AI 动作与关键词监听增加结构化请求/响应/失败日志，记录模型、耗时、图片/文本大小、选项数与 token；包含重试耗时与用量，不记录原文与图片 base64。
  - 任务流支持 `run_id`：首行写入并用于关联，服务端错误日志包含 `run_id`；任务日志流写入脱敏的异常摘要与 traceback，服务端日志保留完整 `exc_info`。
  - `login()` 降噪并新增完成 INFO；`.gitignore` 修正 `.ace-tool/`；CI Docker 构建仅在 `main` 触发。

- **Bug Fixes**
  - 关键词监听的 AI 失败抛出 `TerminalAIActionError` 并在后续动作中按终止错误处理；对应日志改为错误级别且始终记录完整堆栈，避免重试风暴与排障遗漏。
  - `safe_traceback_preview` 保留行首缩进且不折叠空白；`Authorization` 正则完整匹配 Bearer token；任务运行信息与配置更新失败日志级别提升为 warning。

<sup>Written for commit 25091f17b42c20d9ff18292ffe3273648b6ee67f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Silentely/TG-SignPulse/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

