### PR TITLE
fix:登陆验证码发送成功后的 60 秒倒计时文案用了错误的 Vue-i18n 插值语法 {{s}}，导致 Modal 在倒计时期间渲染异…

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -678,7 +678,7 @@
     "codePlaceholder": "Code received",
     "getCode": "Get Code",
     "resendCode": "Resend",
-    "resendIn": "Resend ({{s}}s)",
+    "resendIn": "Resend ({s}s)",
     "cloudPassword": "2FA (Cloud Password)",
     "cloudPasswordPlaceholder": "Leave empty if not set",
     "proxy": "SOCKS5 Proxy (optional)",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -678,7 +678,7 @@
     "codePlaceholder": "收到的验证码",
     "getCode": "获取验证码",
     "resendCode": "重新获取",
-    "resendIn": "重新获取 ({{s}}s)",
+    "resendIn": "重新获取 ({s}s)",
     "cloudPassword": "两步验证(Cloud Password)",
     "cloudPasswordPlaceholder": "未设置请留空",
     "proxy": "SOCKS5 代理 (可选)",


### PR DESCRIPTION
…常；60 秒结束后又自动恢复。

## 变更概述

<!-- 用一两句话描述本次变更的核心内容。 -->

## 变更类型

<!-- 请勾选所有适用项。 -->

- [ ] ✨ feat: 新功能
- [ y] 🐛 fix: Bug 修复
- [ ] ♻️ refactor: 重构（无功能变更）
- [ ] 🎨 style: 样式 / UI 调整
- [ ] 📝 docs: 文档更新
- [ ] 🔧 chore: 构建 / CI / 工具链
- [ ] 🔥 remove: 删除废弃代码
- [ ] test: 测试补充
- [ ] improve: 现有功能改进

## 影响范围

<!-- 请勾选受影响的模块。 -->

- [ y] 前端面板 (`frontend/`)
- [ ] 后端 API (`backend/`)
- [x] 签到引擎 (`tg_signer/`)
- [ ] 文档 (`docs/`)
- [ ] 测试 (`tests/`)
- [ ] CI / Docker
- [ ] 配置 / 工具 (`tools/`)

## 关联 Issue

<!-- 关联的 Issue 编号，无则删除本行。 -->

Closes #

## 变更详情

<!-- 列出关键变更点，说明改了什么、为什么改。 -->

- 登陆获取验证码之后，对话框会被关掉，但是等60秒又出现了
-

## 测试情况

<!-- 说明如何验证本次变更。 -->

- [ ] 已通过本地 pytest 测试
- [ ] 已通过前端 typecheck / build
- [ ] 已手动验证核心流程
- [ ] 不涉及代码变更（仅文档 / 配置）

## 截图（UI 变更适用）

<!-- 如果有 UI 变更，请附截图或录屏。 -->

## 破坏性变更

<!-- 如果有破坏性变更（不向后兼容），请在此说明迁移方式。无则删除本节。 -->

## Checklist

- [ ] 代码符合项目编码规范（PEP 8 / vue-tsc 严格模式）
- [ ] 中文注释，描述意图与使用方式
- [ ] 已更新相关文档（如适用）
- [ ] 已补充测试用例（如适用）

## Summary by Sourcery

Bug Fixes:
- 修复登录验证码发送成功后 60 秒倒计时文案的国际化插值错误，避免倒计时期间 Modal 异常渲染并在结束后重新出现。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the login verification code countdown text so the modal no longer renders incorrectly during the 60-second wait. The `resendIn` message in `en-US.json` and `zh-CN.json` used `{{s}}` instead of the Vue-i18n `{s}` interpolation syntax.

<sup>Written for commit afc09ffc4c0c0d8bb9e366a938c1c07b57ba3d4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Silentely/TG-SignPulse/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

